### PR TITLE
Fixed detection of assigned reviewers

### DIFF
--- a/tom/bot.py
+++ b/tom/bot.py
@@ -69,7 +69,7 @@ class Bot():
             log.info("I have already commented :)")
         elif len(pr.comments) > 0:
             log.info("There are already comments there, so I won't disturb")
-        elif len(pr.reviewers) > 0:
+        elif len(pr.requested_reviewers) > 0:
             log.info("Someone already assigned a reviewer, I won't disturb")
         elif len(pr.reviews) > 0:
             log.info("This PR has reviews already, so I'll leave it to you humans")

--- a/tom/github.py
+++ b/tom/github.py
@@ -397,7 +397,7 @@ class PR():
         self.number = data["number"]
         self.api_url = data["url"]
         self.reviews_url = self.api_url + "/reviews"
-        self.reviewers = data["requested_reviewers"]
+        self.requested_reviewers = data["requested_reviewers"]
 
         self.labels = []
         if "labels" in data:


### PR DESCRIPTION
pr.reviewers was already used for default reviewers in that repo.
Used a more descriptive name, matching the JSON field from API.